### PR TITLE
Recognize delete expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const getAccounts = () => {
 /** Takes a list of commands and evaluates them inside a contract. Returns a promised result of the last command. Returns null if the command is not an expression. */
 const evalSol = (commands, options={}) => {
   /** Returns true if the given command is an expression that can return a value. */
-  const isExpression = command => !/[^=]=[^=]/.test(command)
+  const isExpression = command => (!/[^=]=[^=]/.test(command)) && (!command.startsWith('delete'))
   const lastCommand = commands[commands.length - 1]
 
   let returnType = 'bool'


### PR DESCRIPTION
`delete` expressions need to be recognized in order to avoid an error due to the missing return value.
Test case to show the difference between the old and the new version:
```
uint8[3] memory array = [1,2,3];
delete array[1];
array
```